### PR TITLE
CREATE Totalcomment in PostEntity

### DIFF
--- a/src/main/java/com/UMC/history/DTO/CommonDTO.java
+++ b/src/main/java/com/UMC/history/DTO/CommonDTO.java
@@ -33,10 +33,9 @@ public class CommonDTO {
         String getContents();
         int getTotalClick();
         int getTotalLike();
+        int getTotalComment();
         LocalDateTime getCreatedDate();
         LocalDateTime getLastModifedDate();
-        List<String> getHashTags();
-        List<MultipartFile> getImages();
 
         interface UserEntity{
             String getUserId();

--- a/src/main/java/com/UMC/history/entity/strongEntity/PostEntity.java
+++ b/src/main/java/com/UMC/history/entity/strongEntity/PostEntity.java
@@ -52,6 +52,9 @@ public class PostEntity extends BaseEntity {
     @Column(columnDefinition = "integer default 0")
     private Integer totalClick;
 
+    @Column(columnDefinition = "integer default 0")
+    private Integer totalComment;
+
 
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "post")
     private List<ImageEntity> images = new ArrayList<>();
@@ -60,13 +63,14 @@ public class PostEntity extends BaseEntity {
     private List<HashTagEntity> hashTags = new ArrayList<>();
 
     @Builder
-    public PostEntity(UserEntity user, CategoryEnum category, String title, String contents, Integer totalLike, Integer totalClick, List<ImageEntity> images) {
+    public PostEntity(UserEntity user, CategoryEnum category, String title, String contents, Integer totalLike, Integer totalClick, Integer totalComment, List<ImageEntity> images) {
         this.user = user;
         this.category = category;
         this.title = title;
         this.contents = contents;
         this.totalClick = totalClick;
         this.totalLike = totalLike;
+        this.totalComment = totalComment;
         this.images = images;
     }
 }


### PR DESCRIPTION
[api 생성 X] user가 쓴 글, user가 좋아요 한 글에는 hashtag와 img 가 따로 들어가지 않아 DTO userProtected interface에서 값을 삭제했습니다. 또한,  post entity에 totalComment 개수 column 추가했습니다.  totalComment 가 table을 drop 하지 않고 위에 덮어 쓰였을 때에는 default 값이 생성되지 않습니다.