### PR TITLE
login, reissue return value and No token required API  edit

### DIFF
--- a/src/main/java/com/UMC/history/controller/UserController.java
+++ b/src/main/java/com/UMC/history/controller/UserController.java
@@ -37,8 +37,8 @@ public class UserController {
     }
 
     @PostMapping(value = "/login") //로그인
-    public ResponseEntity<TokenDTO> login(@RequestBody UserDTO.User user) {
-        return ResponseEntity.ok().body(userService.login(user));
+    public CommonResponse<TokenDTO> login(@RequestBody UserDTO.User user) {
+        return new CommonResponse<TokenDTO>(userService.login(user), HttpStatus.OK);
     }
     
     @GetMapping(value = "/sign/{userId}/exist") //id존재여부 확인
@@ -47,8 +47,7 @@ public class UserController {
     }
 
     @PostMapping("/reissue")
-    public ResponseEntity<TokenDTO> reissue(@RequestBody TokenDTO tokenRequestDto) { //RequestBody로 Access Token + Refresh Token를 받는다.
-        return ResponseEntity.ok(userService.reissue(tokenRequestDto));
+    public CommonResponse<TokenDTO> reissue(@RequestBody TokenDTO tokenRequestDto) { //RequestBody로 Access Token + Refresh Token를 받는다.
+        return new CommonResponse<TokenDTO>(userService.reissue(tokenRequestDto), HttpStatus.OK);
     }
-
 }

--- a/src/main/java/com/UMC/history/controller/UserController.java
+++ b/src/main/java/com/UMC/history/controller/UserController.java
@@ -6,7 +6,6 @@ import com.UMC.history.service.UserService;
 import com.UMC.history.util.CommonResponse;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController

--- a/src/main/java/com/UMC/history/util/SpringSecurity.java
+++ b/src/main/java/com/UMC/history/util/SpringSecurity.java
@@ -47,9 +47,9 @@ public class SpringSecurity extends WebSecurityConfigurerAdapter {
                 // 로그인, 회원가입 API, 재발급(header에) 는 토큰이 없는 상태에서 요청이 들어오기 때문에 permitAll 설정
                 .and()
                 .authorizeRequests()
-                .antMatchers("/auth/**").permitAll()
                 .antMatchers("/user/login").permitAll()
                 .antMatchers("/user/sign").permitAll()
+                .antMatchers("/user/sign/**").permitAll()
                 .antMatchers("/user/reissue").permitAll()
                 .anyRequest().authenticated()   // 나머지 API 는 전부 인증 필요
 


### PR DESCRIPTION
로그인과 토큰 재발급에 해당하는 리턴값을 ResponseEntity에서 -> CommonResponse로 변경하였습니다.

추가적으로
토큰이 없는 상태에서 요청이 들어오는 것에 대해 API를 추가하였습니다.
회원가입 하면서 id존재여부를 확인하고 닉네임 중복체크를 하기 때문에 토큰이 필요가 없다고 생각해서 수정하였습니다.