### PR TITLE
댓글 api/ pathvariable -> jwt

### DIFF
--- a/src/main/java/com/UMC/history/DTO/CommonDTO.java
+++ b/src/main/java/com/UMC/history/DTO/CommonDTO.java
@@ -50,4 +50,13 @@ public class CommonDTO {
         LocalDateTime getCreatedDate();
         LocalDateTime getLastModifedDate();
     }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @Builder
+    public static class Comment{
+        private String contents;
+        public Comment(){}
+    }
 }

--- a/src/main/java/com/UMC/history/controller/CommonController.java
+++ b/src/main/java/com/UMC/history/controller/CommonController.java
@@ -2,26 +2,13 @@ package com.UMC.history.controller;
 
 
 import com.UMC.history.DTO.CommonDTO;
-import com.UMC.history.DTO.UserDTO;
 import com.UMC.history.entity.strongEntity.PostEntity;
-import com.UMC.history.entity.strongEntity.UserEntity;
 import com.UMC.history.service.CommonService;
 import com.UMC.history.util.CategoryEnum;
 import com.UMC.history.util.CommonResponse;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import org.apache.catalina.User;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.net.Authenticator;
 import java.security.Principal;
 import java.util.List;
 

--- a/src/main/java/com/UMC/history/controller/CommonController.java
+++ b/src/main/java/com/UMC/history/controller/CommonController.java
@@ -2,19 +2,27 @@ package com.UMC.history.controller;
 
 
 import com.UMC.history.DTO.CommonDTO;
+import com.UMC.history.DTO.UserDTO;
 import com.UMC.history.entity.strongEntity.PostEntity;
+import com.UMC.history.entity.strongEntity.UserEntity;
 import com.UMC.history.service.CommonService;
 import com.UMC.history.util.CategoryEnum;
 import com.UMC.history.util.CommonResponse;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.apache.catalina.User;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.net.Authenticator;
+import java.security.Principal;
 import java.util.List;
 
 @RestController
@@ -45,16 +53,25 @@ public class CommonController {
     }
 
     //user가 쓴 글
-    @GetMapping(value = "/stories/byUser/{userId}")
-    public CommonResponse<List> storyListByUser(@PathVariable("userId") String userId){
-        return new CommonResponse<List>(commonService.storyListByUser(userId), HttpStatus.OK);
+    @GetMapping(value = "/stories/byUser")
+    public CommonResponse<List> storyListByUser(Principal principal){
+        return new CommonResponse<List>(commonService.storyListByUser(principal), HttpStatus.OK);
     }
 
     //user가 좋아요 한 글
-    @GetMapping(value = "/stories/Liking/{userId}")
-    public CommonResponse<List> LikingUser(@PathVariable("userId") String userId){
-        return new CommonResponse<List>(commonService.postLike(userId), HttpStatus.OK);
+    // USER id 로 불러오는 것이 아니라 jwt 값을 제공하면 정보를 불러오는 경우로 변경
+    @GetMapping(value = "/stories/Liking")
+    public CommonResponse<List> LikingUser(Principal principal){
+        return new CommonResponse<List>(commonService.postLike(principal), HttpStatus.OK);
     }
+
+    //댓글
+    @PostMapping(value = "story/comment/{postIdx}")
+    @ResponseStatus(code = HttpStatus.ACCEPTED, reason = "Post success")
+    public void postComment(@PathVariable("postIdx") Long postIdx, Principal principal, @RequestBody CommonDTO.Comment comment){
+        commonService.postComment(postIdx, principal, comment);
+    }
+
 
 
 }

--- a/src/main/java/com/UMC/history/entity/strongEntity/PostEntity.java
+++ b/src/main/java/com/UMC/history/entity/strongEntity/PostEntity.java
@@ -1,7 +1,6 @@
 package com.UMC.history.entity.strongEntity;
 
 
-import com.UMC.history.DTO.CommonDTO;
 import com.UMC.history.entity.weekEntity.HashTagEntity;
 import com.UMC.history.entity.weekEntity.ImageEntity;
 import com.UMC.history.util.BaseEntity;

--- a/src/main/java/com/UMC/history/entity/strongEntity/PostEntity.java
+++ b/src/main/java/com/UMC/history/entity/strongEntity/PostEntity.java
@@ -73,4 +73,6 @@ public class PostEntity extends BaseEntity {
         this.totalComment = totalComment;
         this.images = images;
     }
+
+    public void createComment(int totalComment) {this.totalComment = totalComment;}
 }

--- a/src/main/java/com/UMC/history/entity/strongEntity/UserEntity.java
+++ b/src/main/java/com/UMC/history/entity/strongEntity/UserEntity.java
@@ -58,4 +58,5 @@ public class UserEntity extends BaseEntity {
     public void changeNickName(String nickName) {
         this.nickName = nickName;
     }
+    public void getUserId(Long userIdx){this.userIdx = userIdx;}
 }

--- a/src/main/java/com/UMC/history/repository/CommentRepository.java
+++ b/src/main/java/com/UMC/history/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package com.UMC.history.repository;
+
+import com.UMC.history.entity.weekEntity.CommentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
+}

--- a/src/main/java/com/UMC/history/service/CommonService.java
+++ b/src/main/java/com/UMC/history/service/CommonService.java
@@ -9,8 +9,6 @@ import com.UMC.history.entity.weekEntity.ImageEntity;
 import com.UMC.history.repository.*;
 import com.UMC.history.util.CategoryEnum;
 import com.UMC.history.util.S3Uploader;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestBody;
 

--- a/src/main/java/com/UMC/history/service/CommonService.java
+++ b/src/main/java/com/UMC/history/service/CommonService.java
@@ -3,34 +3,41 @@ package com.UMC.history.service;
 import com.UMC.history.DTO.CommonDTO;
 import com.UMC.history.entity.strongEntity.PostEntity;
 import com.UMC.history.entity.strongEntity.UserEntity;
+import com.UMC.history.entity.weekEntity.CommentEntity;
 import com.UMC.history.entity.weekEntity.HashTagEntity;
 import com.UMC.history.entity.weekEntity.ImageEntity;
 import com.UMC.history.repository.*;
 import com.UMC.history.util.CategoryEnum;
 import com.UMC.history.util.S3Uploader;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import java.security.Principal;
 import java.util.ArrayList;
 import java.util.List;
 
 @Service
 public class CommonService {
 
+    private final int postComment = 1;
     private final PostRepository postRepository;
     private final UserRepository userRepository;
     private final HashTagRepository hashTagRepository;
     private final ImageReposotory imageReposotory;
     private final LikeRepository likeRepository;
+    private final CommentRepository commentRepository;
     private final S3Uploader s3Uploader;
 
-    public CommonService(PostRepository postRepository, UserRepository userRepository, HashTagRepository hashTagRepository, S3Uploader s3Uploader, ImageReposotory imageReposotory, LikeRepository likeRepository) {
+    public CommonService(PostRepository postRepository, UserRepository userRepository, HashTagRepository hashTagRepository, S3Uploader s3Uploader, ImageReposotory imageReposotory, LikeRepository likeRepository, CommentRepository commentRepository) {
         this.postRepository = postRepository;
         this.userRepository = userRepository;
         this.hashTagRepository = hashTagRepository;
         this.imageReposotory = imageReposotory;
         this.s3Uploader = s3Uploader;
         this.likeRepository = likeRepository;
+        this.commentRepository = commentRepository;
     }
 
     public void savePost(@RequestBody CommonDTO.Post post) {
@@ -77,15 +84,27 @@ public class CommonService {
         return post;
     }
 
-    public List<CommonDTO.UserProtected> storyListByUser(String userId) {
-        UserEntity userEntity = userRepository.findByUserId(userId);
+    public List<CommonDTO.UserProtected> storyListByUser(Principal principal) {
+        UserEntity userEntity = userRepository.findByUserId(principal.getName());
         return postRepository.findByUser(userEntity);
     }
 
-    public List<CommonDTO.LikeUserProtected> postLike(String userId){
+    public List<CommonDTO.LikeUserProtected> postLike(Principal principal){
         //COMMENTS 개수 쿼리는 따로 작성
-        UserEntity userEntity = userRepository.findByUserId(userId);
+        UserEntity userEntity = userRepository.findByUserId(principal.getName());
         return likeRepository.findByUser(userEntity);
     }
 
+    public void postComment(Long postIdx, Principal principal, @RequestBody CommonDTO.Comment comment) {
+
+        UserEntity userEntity = userRepository.findByUserId(principal.getName());
+        PostEntity postEntity = postRepository.findById(postIdx).get();
+        CommentEntity commentEntity = CommentEntity.builder()
+                .user(userEntity)
+                .post(postEntity)
+                .contents(comment.getContents())
+                .build();
+        postEntity.createComment(postComment);
+        commentRepository.save(commentEntity);
+    }
 }


### PR DESCRIPTION
댓글을 작성하면 CommentEntity에 글이 작성되고, PostEntity Field TotalComment에 값이 추가됩니다. 네오님께서 user 마다 jwt를 생성해주시면서 pathVariable로 userId 값을 불러오지 않고 jwt의 정보를 불러오면 api 에 값을 받아올 수 있게 되는 것을 확인했습니다. 이에 [댓글], [user가 작성한 글], [user가 좋아요 한 글] api에 jwt를 사용하면 바로 정보를 불러올 수 있도록 변경했습니다. (혹시 pathVariable이 꼭 필요하다면 말씀해주세요:))