### PR TITLE
Login Exception

### DIFF
--- a/src/main/java/com/UMC/history/DTO/TokenDTO.java
+++ b/src/main/java/com/UMC/history/DTO/TokenDTO.java
@@ -12,4 +12,8 @@ public class TokenDTO {
     private String accessToken;
     private String refreshToken;
     private Long accessTokenExpiresIn;
+
+    public void setGrantType(String grantType) {
+        this.grantType = grantType;
+    }
 }

--- a/src/main/java/com/UMC/history/controller/UserController.java
+++ b/src/main/java/com/UMC/history/controller/UserController.java
@@ -44,7 +44,7 @@ public class UserController {
         if (token.getGrantType()=="Id Error"){
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "invalid ID");
         }else if(token.getGrantType()=="Password Error"){ //비밀번호 오류시
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "invalid Password");
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "invalid Password");
         }
         return new CommonResponse<TokenDTO>(token, HttpStatus.OK);
     }

--- a/src/main/java/com/UMC/history/controller/UserController.java
+++ b/src/main/java/com/UMC/history/controller/UserController.java
@@ -7,6 +7,7 @@ import com.UMC.history.util.CommonResponse;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping(value = "/user")
@@ -37,7 +38,15 @@ public class UserController {
 
     @PostMapping(value = "/login") //로그인
     public CommonResponse<TokenDTO> login(@RequestBody UserDTO.User user) {
-        return new CommonResponse<TokenDTO>(userService.login(user), HttpStatus.OK);
+        //로그인 예외처리
+        TokenDTO token=userService.login(user);
+        //아이디 오류시
+        if (token.getGrantType()=="Id Error"){
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "invalid ID");
+        }else if(token.getGrantType()=="Password Error"){ //비밀번호 오류시
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "invalid Password");
+        }
+        return new CommonResponse<TokenDTO>(token, HttpStatus.OK);
     }
     
     @GetMapping(value = "/sign/{userId}/exist") //id존재여부 확인

--- a/src/main/java/com/UMC/history/service/UserService.java
+++ b/src/main/java/com/UMC/history/service/UserService.java
@@ -65,11 +65,15 @@ public class UserService {
     public TokenDTO login(UserDTO.User user) {
         UserEntity findUser = userRepository.findByUserId(user.getId());
         if(findUser == null){
-            return new TokenDTO();
+            TokenDTO token =new TokenDTO();
+            token.setGrantType("Id Error");
+            return token;
         }
 
         if(!passwordEncoder.matches(user.getPassword(), findUser.getPassword())){ // 그냥 받아온 password를 넣으면 알아서 암호화해서 비교함.
-            return new TokenDTO();
+            TokenDTO token =new TokenDTO();
+            token.setGrantType("Password Error");
+            return token;
         }
         // 1. Login ID/PW 를 기반으로 AuthenticationToken 생성
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(user.getId(), user.getPassword());

--- a/src/main/java/com/UMC/history/util/SpringSecurity.java
+++ b/src/main/java/com/UMC/history/util/SpringSecurity.java
@@ -51,7 +51,7 @@ public class SpringSecurity extends WebSecurityConfigurerAdapter {
                 .antMatchers("/user/sign").permitAll()
                 .antMatchers("/user/sign/**").permitAll()
                 .antMatchers("/user/reissue").permitAll()
-                .anyRequest().authenticated()   // 나머지 API 는 전부 인증 필요
+                .anyRequest().authenticated()   // 나머지 API 는 전부 인증 필요 -> 이부분이 들어가면 Postman에서 401,403에러시 body로 응답하는 것이 없음
 
                 // JwtFilter 를 addFilterBefore 로 등록했던 JwtSecurityConfig 클래스를 적용
                 .and()


### PR DESCRIPTION
로그인에서 발생하는 ID오류일때와 PassWord오류일때로 나누어 Message를 다르게 구성해놓았습니다.

이 과정에서 TokenDTO의 grantType에 대한 것에 오류정보를 적어 아이디, 비밀번호로 나누었습니다.

포스트맨으로 테스트시 401, 403인 권한인 경우에 모두 Body를 Response를 하지 않습니다.

이것의 이유를 테스트를 통해 알아보았는데 SpringSecurity파일의 configure함수안의 .anyRequest().authenticated()  때문이었습니다.

이것을 없애면 인증에 대한 부분이 필요없어지는데 이러면 안되서  401과 403에 대한 응답으로 Response의 body로 못 보낼 것 같습니다.
만약 body로 보내야한다면 다른방법을 더 찾아봐야 할 것 같습니다.