### PR TITLE
the number of letters exceeds the limit

### DIFF
--- a/src/main/java/com/UMC/history/entity/strongEntity/PostEntity.java
+++ b/src/main/java/com/UMC/history/entity/strongEntity/PostEntity.java
@@ -84,4 +84,9 @@ public class PostEntity extends BaseEntity {
     public void createComment(int totalComment) {this.totalComment += totalComment;}
     public void createLike(int totalLike) {this.totalLike +=totalLike;}
     public void createClick(int totalClick){this.totalClick += totalClick;}
+    public void contentsLength(String contents){
+        if(contents.length() <30){
+            this.contents = contents;
+        } else this.contents = contents.substring(0, 30) + "...";
+    }
 }

--- a/src/main/java/com/UMC/history/entity/weekEntity/CommentEntity.java
+++ b/src/main/java/com/UMC/history/entity/weekEntity/CommentEntity.java
@@ -4,6 +4,7 @@ import com.UMC.history.DTO.CommonDTO;
 import com.UMC.history.entity.strongEntity.PostEntity;
 import com.UMC.history.entity.strongEntity.UserEntity;
 import com.UMC.history.util.BaseEntity;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,6 +20,7 @@ public class CommentEntity extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long commentIdx;
 
+    @JsonIgnore // interface를 사용하게 되면 원하는 글자 수만 나오게 하는 것을 할 수 없음
     @ManyToOne
     @JoinColumn(name = "postIdx")
     private PostEntity post;
@@ -38,5 +40,10 @@ public class CommentEntity extends BaseEntity {
     }
     public void changeContents(String contents) {
         this.contents = contents;
+    }
+    public void contentsLength(String contents) {
+        if(contents.length() <30){
+            this.contents = contents;
+        } else this.contents = contents.substring(0, 30) + "...";
     }
 }

--- a/src/main/java/com/UMC/history/repository/CommentRepository.java
+++ b/src/main/java/com/UMC/history/repository/CommentRepository.java
@@ -10,5 +10,5 @@ import java.util.List;
 
 @Repository
 public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
-    List<CommentMappingInterface> findByPost(PostEntity postIdx);
+    List<CommentEntity> findByPost(PostEntity postIdx);
 }

--- a/src/main/java/com/UMC/history/repository/LikeRepository.java
+++ b/src/main/java/com/UMC/history/repository/LikeRepository.java
@@ -11,8 +11,9 @@ import java.util.List;
 
 @Repository
 public interface LikeRepository extends JpaRepository<LikeEntity, Long> {
-//    List<CommonDTO.LikeUserProtected> findByUser(UserEntity user);
+    //    List<CommonDTO.LikeUserProtected> findByUser(UserEntity user);
     LikeEntity findByPostAndUser(PostEntity postEntity, UserEntity userEntity);
 
-    List<CommonDTO.LikeUserProtected> findByUserOrderByCreatedDateDesc(UserEntity userEntity);
+    //    List<CommonDTO.LikeUserProtected> findByUserOrderByCreatedDateDesc(UserEntity userEntity);
+    List<LikeEntity> findByUserOrderByCreatedDateDesc(UserEntity userEntity);
 }

--- a/src/main/java/com/UMC/history/repository/PostRepository.java
+++ b/src/main/java/com/UMC/history/repository/PostRepository.java
@@ -12,10 +12,10 @@ import java.util.List;
 
 @Repository
 public interface PostRepository extends JpaRepository<PostEntity, Long> {
-//    List<PostEntity> findByCategory(CategoryEnum category);
+    //    List<PostEntity> findByCategory(CategoryEnum category);
     List<CommonDTO.UserProtected> findByUser(UserEntity userIdx);
-    List<CommonDTO.UserProtected> findByContentsContainsOrderByCreatedDateDesc(String keyword);
-    List<CommonDTO.UserProtected> findByTitleContainsOrderByCreatedDateDesc(String keyword);
+    List<PostEntity> findByContentsContainsOrderByCreatedDateDesc(String keyword);
+    List<PostEntity> findByTitleContainsOrderByCreatedDateDesc(String keyword);
 
     @Query(value="SELECT * FROM post order by rand() limit 1",nativeQuery = true)
     PostEntity findByOrderByRand();
@@ -28,5 +28,7 @@ public interface PostRepository extends JpaRepository<PostEntity, Long> {
 
     List<PostEntity> findByOrderByTotalLikeDesc();
 
-    List<CommonDTO.UserProtected> findByUserOrderByCreatedDateDesc(UserEntity userEntity);
+//    List<CommonDTO.UserProtected> findByUserOrderByCreatedDateDesc(UserEntity userEntity);
+
+    List<PostEntity> findByUserOrderByCreatedDateDesc(UserEntity userEntity);
 }

--- a/src/main/java/com/UMC/history/service/CommonService.java
+++ b/src/main/java/com/UMC/history/service/CommonService.java
@@ -75,20 +75,32 @@ public class CommonService {
 
     }
 
+    // 글자수 처리 완료
     public List<PostEntity> storyListByCategoryOrderByDate(CategoryEnum category) {
-        return postRepository.findByCategoryOrderByCreatedDateDesc(category);
+        List<PostEntity> post =  postRepository.findByCategoryOrderByCreatedDateDesc(category);
+        post.stream().forEach(o -> o.contentsLength(o.getContents()));
+        return post;
     }
 
+    // 글자수 처리 완료
     public List<PostEntity> storyListByOrderByDate() {
-        return postRepository.findByOrderByCreatedDateDesc();
+        List<PostEntity> post =  postRepository.findByOrderByCreatedDateDesc();
+        post.stream().forEach(o -> o.contentsLength(o.getContents()));
+        return post;
     }
 
+    // 글자수 처리 완료
     public List<PostEntity> storyListByCategoryOrderByLike(CategoryEnum category) {
-        return postRepository.findByCategoryOrderByTotalLikeDesc(category);
+        List<PostEntity> post =  postRepository.findByCategoryOrderByTotalLikeDesc(category);
+        post.stream().forEach(o -> o.contentsLength(o.getContents()));
+        return post;
     }
 
+    // 글자수 처리 완료
     public List<PostEntity> storyListByOrderByLike() {
-        return postRepository.findByOrderByTotalLikeDesc();
+        List<PostEntity> post = postRepository.findByOrderByTotalLikeDesc();
+        post.stream().forEach(o -> o.contentsLength(o.getContents()));
+        return post;
     }
 
     public PostEntity selectById(Long postIdx) {
@@ -107,15 +119,21 @@ public class CommonService {
         return lockPost;
     }
 
-    public List<CommonDTO.UserProtected> storyListByUser(Principal principal) {
+    // 글자수 처리 완료
+    public List<PostEntity> storyListByUser(Principal principal) {
         UserEntity userEntity = userRepository.findByUserId(principal.getName());
-        return postRepository.findByUserOrderByCreatedDateDesc(userEntity);
+        List<PostEntity> post = postRepository.findByUserOrderByCreatedDateDesc(userEntity);
+        post.stream().forEach(o -> o.contentsLength(o.getContents()));
+        return post;
     }
 
-    public List<CommonDTO.LikeUserProtected> postLike(Principal principal){
+    // 글자수 처리 완료
+    public List<LikeEntity> postLike(Principal principal){
         //COMMENTS 개수 쿼리는 따로 작성
         UserEntity userEntity = userRepository.findByUserId(principal.getName());
-        return likeRepository.findByUserOrderByCreatedDateDesc(userEntity);
+        List<LikeEntity> like =  likeRepository.findByUserOrderByCreatedDateDesc(userEntity);
+        like.stream().forEach(o -> o.getPost().contentsLength(o.getPost().getContents()));
+        return like;
     }
 
     public void postComment(Long postIdx, Principal principal, @RequestBody CommonDTO.Comment comment) {
@@ -131,9 +149,12 @@ public class CommonService {
         commentRepository.save(commentEntity);
     }
 
-    public List<CommentMappingInterface> commentListByPostIdx(Long postIdx){
+    //글자수 처리 완료
+    public List<CommentEntity> commentListByPostIdx(Long postIdx){
         PostEntity post = postRepository.findById(postIdx).get();
-        return commentRepository.findByPost(post);
+        List<CommentEntity> commentEntities = commentRepository.findByPost(post);
+        commentEntities.stream().forEach(o->o.contentsLength(o.getContents()));
+        return commentEntities;
     }
 
 
@@ -170,12 +191,18 @@ public class CommonService {
     }
 
 
-    public List<CommonDTO.UserProtected> searchInContents(String keyword){
-        return postRepository.findByContentsContainsOrderByCreatedDateDesc(keyword);
+    // 글자수 처리 완료
+    public List<PostEntity> searchInContents(String keyword){
+        List<PostEntity> post = postRepository.findByContentsContainsOrderByCreatedDateDesc(keyword);
+        post.stream().forEach(o -> o.contentsLength(o.getContents()));
+        return post;
     }
 
-    public List<CommonDTO.UserProtected> searchInTitle(String keyword){
-        return postRepository.findByTitleContainsOrderByCreatedDateDesc(keyword);
+    // 글자수 처리 완료
+    public List<PostEntity> searchInTitle(String keyword){
+        List<PostEntity> post = postRepository.findByTitleContainsOrderByCreatedDateDesc(keyword);
+        post.stream().forEach(o -> o.contentsLength(o.getContents()));
+        return post;
     }
 
     public boolean likingPostUser(Long postIdx, Principal principal) {


### PR DESCRIPTION
**글자 수, 댓글 수가 길어지면 일정 부분만 나오게 하고 나머지는 "..." 처리** 하도록 했습니다. 따로 UserProtected, CommentMappingInterface interface를 사용하게 되면 일정 부분의 글자 수만 받아올 수 없기 때문에 Entity를 받아왔습니다. (아직 interface는 삭제하지 않았습니다. 꼭 interface로 받아와야 하는 경우에는 위 코드를 사용할 수 없습니다.) 이에, CommentEntity에서 Post와 관련된 내용을 받아올 필요가 없어 JsonIgnore를 추가했으니 확인 해 봐주세요. 글을 불러오는 모든 api와 댓글을 불러오는 api에 추가는 했지만, 아직 불러와지지 않는 부분이 있을 수 있습니다.