### PR TITLE
DELETE & USER INFORMATION

### DIFF
--- a/src/main/java/com/UMC/history/controller/UserController.java
+++ b/src/main/java/com/UMC/history/controller/UserController.java
@@ -3,6 +3,7 @@ package com.UMC.history.controller;
 import com.UMC.history.DTO.QuizDTO;
 import com.UMC.history.DTO.TokenDTO;
 import com.UMC.history.DTO.UserDTO;
+import com.UMC.history.entity.strongEntity.UserEntity;
 import com.UMC.history.entity.weekEntity.QuizEntity;
 import com.UMC.history.service.UserService;
 import com.UMC.history.util.CommonResponse;
@@ -10,6 +11,8 @@ import com.UMC.history.util.CommonResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.security.Principal;
 
 @RestController
 @RequestMapping(value = "/user")
@@ -60,6 +63,19 @@ public class UserController {
     public CommonResponse<TokenDTO> reissue(@RequestBody TokenDTO tokenRequestDto) { //RequestBody로 Access Token + Refresh Token를 받는다.
         return new CommonResponse<TokenDTO>(userService.reissue(tokenRequestDto), HttpStatus.OK);
     }
+
+    //유저 정보 불러오기 <프로필 정보>
+    @GetMapping(value = "/information")
+    public CommonResponse<UserEntity> informationAboutUser(Principal principal){
+        return new CommonResponse<UserEntity>(userService.informationAboutUser(principal), HttpStatus.OK);
+    }
+
+    //회원 탈퇴
+    @DeleteMapping(value = "/delete/{password}")
+    public CommonResponse<Boolean> deleteUser(@PathVariable ("password") String password, Principal principal){
+        return new CommonResponse<Boolean>(userService.deleteUser(password, principal), HttpStatus.OK);
+    }
+
 
     //퀴즈 등록 - 단 ROLE_ADMIN유저만 접근 가능
     @PostMapping("/admin/quiz/register")

--- a/src/main/java/com/UMC/history/mappingInterface/CommentMappingInterface.java
+++ b/src/main/java/com/UMC/history/mappingInterface/CommentMappingInterface.java
@@ -1,9 +1,9 @@
-package com.UMC.history.mappingInterface;
-
-import com.UMC.history.entity.strongEntity.UserEntity;
-
-public interface CommentMappingInterface {
-    Long getCommentIdx();
-    UserEntity getUser();
-    String getContents();
-}
+//package com.UMC.history.mappingInterface;
+//
+//import com.UMC.history.entity.strongEntity.UserEntity;
+//
+//public interface CommentMappingInterface {
+//    Long getCommentIdx();
+//    UserEntity getUser();
+//    String getContents();
+//}

--- a/src/main/java/com/UMC/history/repository/CommentRepository.java
+++ b/src/main/java/com/UMC/history/repository/CommentRepository.java
@@ -1,8 +1,9 @@
 package com.UMC.history.repository;
 
 import com.UMC.history.entity.strongEntity.PostEntity;
+import com.UMC.history.entity.strongEntity.UserEntity;
 import com.UMC.history.entity.weekEntity.CommentEntity;
-import com.UMC.history.mappingInterface.CommentMappingInterface;
+//import com.UMC.history.mappingInterface.CommentMappingInterface;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +12,5 @@ import java.util.List;
 @Repository
 public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
     List<CommentEntity> findByPost(PostEntity postIdx);
+    List<CommentEntity> findByUser(UserEntity user);
 }

--- a/src/main/java/com/UMC/history/service/CommonService.java
+++ b/src/main/java/com/UMC/history/service/CommonService.java
@@ -4,7 +4,7 @@ import com.UMC.history.DTO.CommonDTO;
 import com.UMC.history.entity.strongEntity.PostEntity;
 import com.UMC.history.entity.strongEntity.UserEntity;
 import com.UMC.history.entity.weekEntity.*;
-import com.UMC.history.mappingInterface.CommentMappingInterface;
+//import com.UMC.history.mappingInterface.CommentMappingInterface;
 import com.UMC.history.repository.*;
 import com.UMC.history.util.CategoryEnum;
 import com.UMC.history.util.S3Uploader;


### PR DESCRIPTION
프로필에서 회원 정보가 필요해보여서 회원 정보 가져오는 api와 회원 탈퇴하는 api 생성했습니다. 모든 entity가 양방향으로 되어 있지 않아 userRepository deletyById를 사용하면 integrity가 발생하게 됩니다. 하지만, 양방향으로 설정하는 대신에 모든 entity에 직접 정보를 지우는 방식을 선택했습니다.