### PR TITLE
ADD & Edit QUIZ API

### DIFF
--- a/src/main/java/com/UMC/history/controller/UserController.java
+++ b/src/main/java/com/UMC/history/controller/UserController.java
@@ -83,4 +83,10 @@ public class UserController {
     public void registerQuiz(@RequestBody QuizDTO.Quiz quiz) {
         userService.registerQuiz(quiz);
     }
+
+    //퀴즈 삭제 - 단 ROLE_ADMIN유저만 접근 가능
+    @DeleteMapping("/admin/quiz/delete/{quizIdx}")
+    public CommonResponse<Boolean> deleteQuiz(@PathVariable ("quizIdx") Long quizIdx) {
+        return new CommonResponse<Boolean>(userService.deleteQuiz(quizIdx), HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/UMC/history/repository/QuizRepository.java
+++ b/src/main/java/com/UMC/history/repository/QuizRepository.java
@@ -12,9 +12,11 @@ import java.util.List;
 
 @Repository
 public interface QuizRepository extends JpaRepository<QuizEntity, Long> {
-    @Query(value="SELECT * FROM quiz order by rand()",nativeQuery = true)
+    @Query(value="SELECT * FROM quiz order by rand() Limit 5",nativeQuery = true)
     List<QuizEntity> findByOrderByRand();
 
-    @Query(value="SELECT * FROM quiz WHERE category=:categoryName order by rand()",nativeQuery = true)
+    @Query(value="SELECT * FROM quiz WHERE category=:categoryName order by rand() Limit 5",nativeQuery = true)
     List<QuizEntity> findByCategoryOrderByRand(@Param("categoryName")String category);
+
+    Boolean existsByQuizIdx(Long quizIdx);
 }

--- a/src/main/java/com/UMC/history/service/CommonService.java
+++ b/src/main/java/com/UMC/history/service/CommonService.java
@@ -229,10 +229,10 @@ public class CommonService {
     }
 
     public List<QuizEntity> quizList(){
-        return quizRepository.findByOrderByRand().subList(0,5);
+        return quizRepository.findByOrderByRand();
     }
 
     public List<QuizEntity> quizListByCategory(CategoryEnum category){
-        return quizRepository.findByCategoryOrderByRand(category.name()).subList(0,5);
+        return quizRepository.findByCategoryOrderByRand(category.name());
     }
 }

--- a/src/main/java/com/UMC/history/service/UserService.java
+++ b/src/main/java/com/UMC/history/service/UserService.java
@@ -186,4 +186,12 @@ public class UserService {
         }else return false;
 
     }
+
+    public Boolean deleteQuiz(Long quizIdx){
+        if (quizRepository.existsByQuizIdx(quizIdx)){
+            quizRepository.deleteById(quizIdx);
+            return true;
+        }
+        else return false;
+    }
 }

--- a/src/main/java/com/UMC/history/util/SpringSecurity.java
+++ b/src/main/java/com/UMC/history/util/SpringSecurity.java
@@ -52,6 +52,7 @@ public class SpringSecurity extends WebSecurityConfigurerAdapter {
                 .antMatchers("/user/sign/**").permitAll()
                 .antMatchers("/user/reissue").permitAll()
                 .antMatchers("/user/admin/quiz/register").hasAuthority("ROLE_ADMIN")
+                .antMatchers("/user/admin/quiz/delete").hasAuthority("ROLE_ADMIN")
                 .antMatchers("/common/story/**").permitAll()
                 .antMatchers("/common/stories/**").permitAll()
                 .anyRequest().authenticated()   // 나머지 API 는 전부 인증 필요 -> 이부분이 들어가면 Postman에서 401,403에러시 body로 응답하는 것이 없음


### PR DESCRIPTION
올렸던 Quiz를 Delete요청으로 삭제합니다.
이때 ROLE_ADMIN만 접근이 가능합니다.
Path Variable로 QuizIdx를 전달해야합니다.

Response로는 status와 body를 return합니다.

퀴즈 조회시 5개만 조회를 코드상 수정